### PR TITLE
Fix null query with using where in where

### DIFF
--- a/.circleci/Gemfile
+++ b/.circleci/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+if RUBY_VERSION < '3.0'
+  gem 'activerecord', '~> 6.1.0'
+  gem 'activesupport', '~> 6.1.0'
+end
+
+gemspec :path => '../'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,9 @@ jobs:
         name: bundle install
         command: |
           gem update bundler
+          bundle config --local path ../vendor/bundle
+          bundle install --gemfile .circleci/Gemfile --jobs=4 --retry=3
           bundle config --local path vendor/bundle
-          bundle install --jobs=4 --retry=3
     - run:
         name: Setup databases
         command: bundle exec rake db:prepare
@@ -44,3 +45,4 @@ workflows:
           parameters:
             version:
             - "2.7"
+            - "3.0"

--- a/lib/octoball/association.rb
+++ b/lib/octoball/association.rb
@@ -5,6 +5,12 @@ class Octoball
     attr_accessor :current_shard
   end
 
+  module RelationProxyIsARelation
+    def ===(other)
+      other.is_a?(self)
+    end
+  end
+
   module ShardedCollectionAssociation
     [:writer, :ids_reader, :ids_writer, :create, :create!,
      :build, :include?, :load_target, :reload, :size, :select].each do |method|
@@ -71,6 +77,7 @@ class Octoball
   end
 
   ::ActiveRecord::Relation.prepend(RelationCurrentShard)
+  ::ActiveRecord::Relation.singleton_class.prepend(RelationProxyIsARelation)
   ::ActiveRecord::QueryMethods::WhereChain.prepend(RelationCurrentShard)
   ::ActiveRecord::Associations::CollectionAssociation.prepend(ShardedCollectionAssociation)
   ::ActiveRecord::Associations::CollectionProxy.singleton_class.prepend(ShardedCollectionProxyCreate)

--- a/spec/octoball/relation_proxy_spec.rb
+++ b/spec/octoball/relation_proxy_spec.rb
@@ -52,6 +52,20 @@ describe Octoball::RelationProxy do
       end
     end
 
+    context 'when a relation is used in where clause' do
+      it 'specifies the scope without a shard' do
+        client = Client.where(id: @client.id)
+        items = Item.using(:canada).where(client: client)
+        expect(items.to_a).to eq(@client.items.to_a)
+      end
+
+      it 'specifies the scope with a shard' do
+        client = Client.using(:canada).where(id: @client.id)
+        items = Item.using(:canada).where(client: client)
+        expect(items.to_a).to eq(@client.items.to_a)
+      end
+    end
+
     context 'when comparing to other Relation objects' do
       before :each do
         @relation.reset


### PR DESCRIPTION
As reported in Issue #1, when `ModelX.using(:shard_xxx).where(...)` is used in another where as a parameter, NULL ids are queried and results in failure to get records. For example:
```ruby
        Item.using(:canada).where(client: Client.where(id: ...))
```
works, but
```ruby
        Item.using(:canada).where(client: Client.using(:canada).where(id: ...))
```
had generated a NULL query:
```sql
"SELECT `items`.* FROM `items` WHERE `items`.`client_id` = NULL"
```

This was because `ActiveRecord::Relation === <<an instance of RelationProxy>>` is evaluated as `false` in case-when statements in query builder of ActiveRecord.

This PR fixes the issue by patching `ActiveRecord::Relation.===(o)` to redirect `o.is_a?(self)`.
