### PR TITLE
Solved AS::LogSubscriber#color DEPRECATION WARNING

### DIFF
--- a/lib/octoball/log_subscriber.rb
+++ b/lib/octoball/log_subscriber.rb
@@ -12,7 +12,11 @@ class Octoball
     private
 
     def debug(progname = nil, &block)
-      conn = current_shard ? color("[Shard: #{current_shard}]", ActiveSupport::LogSubscriber::GREEN, true) : ''
+      if ActiveRecord.gem_version >= Gem::Version.new('7.1.0')
+        conn = current_shard ? color("[Shard: #{current_shard}]", ActiveSupport::LogSubscriber::GREEN, bold: true) : ''
+      else
+        conn = current_shard ? color("[Shard: #{current_shard}]", ActiveSupport::LogSubscriber::GREEN, true) : ''
+      end
       super(conn + progname.to_s, &block)
     end
   end


### PR DESCRIPTION
ActiveSupport::LogSubscriber#color bolding options was changed in rails 7.1.0
ref: https://github.com/rails/rails/pull/45976

Bolding options (by positional arguments) is deprecated 

> DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead
