### PR TITLE
Support rails7.1

### DIFF
--- a/.github/Gemfile
+++ b/.github/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 if RUBY_VERSION < '3.0'
-  gem 'activerecord', '~> 6.1.0'
-  gem 'activesupport', '~> 6.1.0'
+  gem 'activerecord', '~> 7.1.1'
+  gem 'activesupport', '~> 7.1.1'
 end
 
 gemspec :path => '../'

--- a/lib/octoball/connection_handling.rb
+++ b/lib/octoball/connection_handling.rb
@@ -4,13 +4,15 @@ class Octoball
   module ConnectionHandlingAvoidAutoLoadProxy
     private
 
-    def swap_connection_handler(handler, &blk)
-      old_handler, ActiveRecord::Base.connection_handler = ActiveRecord::Base.connection_handler, handler
-      return_value = yield
-      return_value.load if !return_value.respond_to?(:ar_relation) && return_value.is_a?(ActiveRecord::Relation)
-      return_value
-    ensure
-      ActiveRecord::Base.connection_handler = old_handler
+    if ActiveRecord.gem_version < Gem::Version.new('7.1.0')
+      def swap_connection_handler(handler, &blk)
+        old_handler, ActiveRecord::Base.connection_handler = ActiveRecord::Base.connection_handler, handler
+        return_value = yield
+        return_value.load if !return_value.respond_to?(:ar_relation) && return_value.is_a?(ActiveRecord::Relation)
+        return_value
+      ensure
+        ActiveRecord::Base.connection_handler = old_handler
+      end
     end
   end
 

--- a/lib/octoball/log_subscriber.rb
+++ b/lib/octoball/log_subscriber.rb
@@ -12,7 +12,11 @@ class Octoball
     private
 
     def debug(progname = nil, &block)
-      conn = current_shard ? color("[Shard: #{current_shard}]", ActiveSupport::LogSubscriber::GREEN, true) : ''
+      if ActiveRecord.gem_version >= Gem::Version.new('7.1.0')
+        conn = current_shard ? color("[Shard: #{current_shard}]", ActiveSupport::LogSubscriber::GREEN, bold: true) : ''
+      else
+        conn = current_shard ? color("[Shard: #{current_shard}]", ActiveSupport::LogSubscriber::GREEN, true) : ''
+      end
       super(conn + progname.to_s, &block)
     end
   end

--- a/spec/octoball/model_spec.rb
+++ b/spec/octoball/model_spec.rb
@@ -123,7 +123,7 @@ describe Octoball do
 
     it 'should clean #current_shard from proxy when using execute' do
       User.using(:canada).connection.execute('select * from users limit 1;')
-      expect(User.connection.current_shard).to eq(:default)
+      expect(User.connection.current_shard).to eq(:master)
     end
 
     it 'should allow scoping dynamically' do
@@ -264,7 +264,7 @@ describe Octoball do
 
   describe 'AR basic methods' do
     it 'connects_to' do
-      expect(CustomConnection.connection.current_database).to eq('octoball_shard_2')
+      expect(CustomConnection.connection.current_database).to eq('octoball_shard_3')
     end
 
     it 'reuses parent model connection' do
@@ -590,7 +590,7 @@ describe Octoball do
   describe 'custom connection' do
     context 'by default' do
       it 'with plain call should use custom connection' do
-        expect(CustomConnection.connection.current_database).to eq('octoball_shard_2')
+        expect(CustomConnection.connection.current_database).to eq('octoball_shard_3')
       end
 
       it 'should use model-specific shard' do


### PR DESCRIPTION
## Changes

  * fix failed spec (ActiveRecord has been modified to use default_shards estimation with keys.first of connects_to hash)
  * Fix swap_connection_handler patch. this method has been removed.
  * used the modification to PR #8.

spec (on CI) now works with rails 7.1. It is desirable to test with multiple versions. It would be nice to add matrix tests to this repository in the future
