### PR TITLE
Wrap ActiveRecord::Base with on_load(:active_record) hook

### DIFF
--- a/lib/octoball.rb
+++ b/lib/octoball.rb
@@ -2,29 +2,15 @@
 
 require 'active_record'
 require 'octoball/version'
-require 'octoball/relation_proxy'
-require 'octoball/connection_adapters'
-require 'octoball/connection_handling'
-require 'octoball/current_shard_tracker'
-require 'octoball/association'
-require 'octoball/association_shard_check'
-require 'octoball/persistence'
-require 'octoball/log_subscriber'
 
-class Octoball
-  def self.using(shard, &block)
-    ActiveRecord::Base.connected_to(role: current_role, shard: shard&.to_sym, &block)
-  end
-
-  def self.current_role
-    ActiveRecord::Base.current_role || ActiveRecord::Base.writing_role
-  end
-
-  module UsingShard
-    def using(shard)
-      Octoball::RelationProxy.new(all, shard&.to_sym)
-    end
-  end
-
-  ::ActiveRecord::Base.singleton_class.prepend(UsingShard)
+ActiveSupport.on_load(:active_record) do
+  require 'octoball/relation_proxy'
+  require 'octoball/connection_adapters'
+  require 'octoball/connection_handling'
+  require 'octoball/current_shard_tracker'
+  require 'octoball/association_shard_check'
+  require 'octoball/persistence'
+  require 'octoball/association'
+  require 'octoball/log_subscriber'
+  require 'octoball/using_shard'
 end

--- a/lib/octoball/using_shard.rb
+++ b/lib/octoball/using_shard.rb
@@ -1,0 +1,17 @@
+class Octoball
+  def self.using(shard, &block)
+    ActiveRecord::Base.connected_to(role: current_role, shard: shard&.to_sym, &block)
+  end
+
+  def self.current_role
+    ActiveRecord::Base.current_role || ActiveRecord::Base.writing_role
+  end
+
+  module UsingShard
+    def using(shard)
+      Octoball::RelationProxy.new(all, shard&.to_sym)
+    end
+  end
+
+  ::ActiveRecord::Base.singleton_class.prepend(UsingShard)
+end


### PR DESCRIPTION
## Description

This PR fixes an issue where `ActiveRecord` configurations like `config/initializers/new_framework_defaults*.rb` are not applied when using `octoball` gem.
This issue is caused by accessing `ActiveRecord::Base` too early during `Bundler.require` step in `config/application.rb`.
So we should use `ActiveSupport.on_load` hook.

## Steps to Reproduce

Save following script as `issue.rb` and run it in terminal like `$ ruby issue.rb`:

```ruby
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"
  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", "7.0.8.1"
  gem "mysql2"
  gem "octoball" # fail test
  # gem "octoball", github: "iberianpig/octoball", branch: "ar_on_load" # fixed
end

require "rails/all"

class TestApp < Rails::Application
  config.load_defaults 6.1
end

db_config_admin = {
  adapter: "mysql2",
  host: ENV["MYSQL_HOST"] || "localhost",
  username: ENV["MYSQL_USER"] || "root",
}
db_config = db_config_admin.merge(
  database: "rails_test_database"
)
ENV["DATABASE_URL"] = "mysql2://#{db_config[:username]}@#{db_config[:host]}/#{db_config[:database]}"

Rails.application.initialize!

# enable defaults with config/initializers/new_framework_defaults_7_0.rb
# ref: https://github.com/rails/rails/blob/7-0-stable/railties/lib/rails/generators/rails/app/templates/config/initializers/new_framework_defaults_7_0.rb.tt?plain=1#L58-L61
Rails.application.config.active_record.partial_inserts = false

ActiveRecord::Schema.define do
  create_table :posts, force: true do |t|
    t.string :title, default: "default title"
  end
end

class Post < ActiveRecord::Base; end

require "minitest/autorun"

class BugTest < Minitest::Test
  def test_partial_inserts
    assert_equal ActiveRecord::Base.partial_inserts, false

    query_logs = []
    ActiveRecord::Base.logger.stub(:debug, ->(msg) { query_logs << msg }) { Post.create }
    insert_log = query_logs.find { |log| log.include?("INSERT INTO `posts`") }

    sql = %q{INSERT INTO `posts` (`title`) VALUES ('default title')}
    assert insert_log.include?(sql), "expected #{sql}, but got #{insert_log}"
  end
end
```

<details>
<summary> fail test because `ActiveRecord::Base.partial_inserts` is not applied.
</summary>

```
Run options: --seed 37768

# Running:

F

Failure:
BugTest#test_partial_inserts [issue.rb:62]:
expected INSERT INTO `posts` (`title`) VALUES ('default title'), but got   Post Create (0.1ms)  INSERT INTO `posts` VALUES ()


rails test issue.rb:56

F

Failure:
BugTest#test_config_active_record [issue.rb:53]:
Expected: true
  Actual: false


rails test issue.rb:52



Finished in 0.009805s, 203.9806 runs/s, 203.9806 assertions/s.
2 runs, 2 assertions, 2 failures, 0 errors, 0 skips
```

</details>

<details>
<summary>
pass test with `ar_on_load` Branch
</summary>

To test the `ar_on_load` branch, uncomment the following line:

```ruby
# gem "octoball", github: "iberianpig/octoball", branch: "ar_on_load" # fixed
```

```
# Running:

..

Finished in 0.009194s, 217.5258 runs/s, 217.5258 assertions/s.
2 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```

With this fix, the tests pass and confirm that the `ActiveRecord::Base.partial_inserts` settings are correctly applied.

</details>
