### PR TITLE
fix deprecation warning when test model_spec.rb

### DIFF
--- a/spec/octoball/model_spec.rb
+++ b/spec/octoball/model_spec.rb
@@ -618,7 +618,7 @@ describe Octoball do
         CustomConnection.create(:value => 'custom value')
 
         # This is what Rails, Sidekiq etc call--this normally handles all connection pools in the app
-        expect { ActiveRecord::Base.clear_active_connections! }
+        expect { ActiveRecord::Base.connection_handler.clear_active_connections! }
           .to change { CustomConnection.connection_pool.active_connection? }
 
         expect(CustomConnection.connection_pool.active_connection?).to be_falsey


### PR DESCRIPTION
### Summary
This PR fixes a deprecation warning that appears when running tests with RSpec: `DEPRECATION WARNING: Calling ActiveRecord::Base.clear_active_connections! is deprecated. Please call the method directly on the connection handler`.

### Changes
Replaced calls to `ActiveRecord::Base.clear_active_connections!` with `ActiveRecord::Base.connection_handler.clear_active_connections!` to remove the deprecation warning.

### Testing
Ran all RSpec tests to confirm no new errors or warnings are introduced.
