### PR TITLE
bump Octoball::VERSION to 0.1.6.1

### DIFF
--- a/lib/octoball/version.rb
+++ b/lib/octoball/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Octoball
-  VERSION = '0.1.4'
+  VERSION = '0.1.6.1'
 end


### PR DESCRIPTION
I generated git tags for v0.1.5 (rails7 support #9 ) and v0.1.6 (fix AS::on_load hook #10 ) but forgot to increment the corresponding Octoball::VERSION (lib/version.rb).

I'll generate a tag 0.1.6.1 after this PR