### PR TITLE
Support rails 7.2 and Drop EOL versions(ruby 2.7, 3.0 and rails 6.1)

### DIFF
--- a/.github/Gemfile
+++ b/.github/Gemfile
@@ -1,8 +1,3 @@
 source 'https://rubygems.org'
 
-if RUBY_VERSION < '3.0'
-  gem 'activerecord', '~> 7.1.1'
-  gem 'activesupport', '~> 7.1.1'
-end
-
 gemspec :path => '../'

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -17,14 +17,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: ["2.7","3.0","3.1","3.2"]
+        ruby: ["3.1","3.2","3.3"]
     env:
       BUNDLE_GEMFILE: .github/Gemfile
       MYSQL_HOST: 127.0.0.1
       RAILS_ENV: test
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,11 @@ namespace :db do
     require './spec/models/application_record'
     ActiveRecord::Base.configurations.configs_for(env_name: "test").each do |config|
       ActiveRecord::Base.establish_connection(config)
-      schema_migration = ActiveRecord::Base.connection.schema_migration
+      schema_migration = if ActiveRecord.gem_version >= Gem::Version.new(7.2)
+                           ActiveRecord::Base.connection.pool.schema_migration
+                         else
+                           ActiveRecord::Base.connection.schema_migration
+                         end
       ActiveRecord::MigrationContext.new("spec/migration", schema_migration)
         .migrate(config.database == 'octoball_shard_5' ? 2 : 1)
     end

--- a/lib/octoball/connection_adapters.rb
+++ b/lib/octoball/connection_adapters.rb
@@ -13,6 +13,41 @@ class Octoball
     attr_accessor :current_shard
   end
 
+  if ActiveRecord.gem_version >= Gem::Version.new('7.2.0')
+    module ConnectionPoolSetCurrentShard
+      def with_connection(prevent_permanent_checkout: false)
+        lease = connection_lease
+        if lease.connection
+          lease.connection.current_shard = lease.connection.shard
+        end
+
+        super
+      end
+
+      def active_connection?
+        conn = connection_lease.connection
+        conn.current_shard = conn.shard if conn
+        conn
+      end
+
+      def active_connection
+        conn = connection_lease.connection
+        conn.current_shard = conn.shard if conn
+        conn
+      end
+
+      def lease_connection
+        lease = connection_lease
+        lease.sticky = true
+        lease.connection ||= checkout
+        lease.connection.current_shard = lease.connection.shard
+        lease.connection
+      end
+    end
+
+    ::ActiveRecord::ConnectionAdapters::ConnectionPool.prepend(ConnectionPoolSetCurrentShard)
+  end
+
   ::ActiveRecord::ConnectionAdapters::ConnectionHandler.prepend(ConnectionHandlerSetCurrentShard)
   ::ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend(ConnectionHasCurrentShard)
 end

--- a/octoball.gemspec
+++ b/octoball.gemspec
@@ -15,14 +15,14 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/aktsk/octoball'
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 3.1.0'
 
-  s.add_dependency 'activerecord', '>= 6.1'
-  s.add_dependency 'activesupport', '>= 6.1'
+  s.add_dependency 'activerecord', '>= 7.0'
+  s.add_dependency 'activesupport', '>= 7.0'
 
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '>= 3'
   s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'byebug'
+  s.add_development_dependency 'debug'
 end


### PR DESCRIPTION
ref: https://edgeguides.rubyonrails.org/7_2_release_notes.html

## Changes

* schema_migration has been changed to go through the pool instead of AR::Base.connection.
* I've created the ConnectionPoolSetcurrentShard module so that conn.current_shard is assigned.

* DROP EOL ruby / rails version
  * Ruby 2.7, 3.0 is already EOL ref: https://www.ruby-lang.org/ja/downloads/branches/
  * Rails 6.1 will reach EOL on 2024/10/01, so it will be deleted. ref: https://railsguides.jp/maintenance_policy.html