### PR TITLE
Add matrix testing for Rails 7.x/8.0 to GitHub Actions

### DIFF
--- a/.github/gemfiles/rails_7.1.gemfile
+++ b/.github/gemfiles/rails_7.1.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec :path => '../../'
+
+gem 'activerecord', '~> 7.1.0'
+gem 'activesupport', '~> 7.1.0'

--- a/.github/gemfiles/rails_7.2.gemfile
+++ b/.github/gemfiles/rails_7.2.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec :path => '../../'
+
+gem 'activerecord', '~> 7.2.0'
+gem 'activesupport', '~> 7.2.0'

--- a/.github/gemfiles/rails_8.0.gemfile
+++ b/.github/gemfiles/rails_8.0.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec :path => '../../'
+
+gem 'activerecord', '~> 8.0.0'
+gem 'activesupport', '~> 8.0.0'

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -17,9 +17,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: ["3.1","3.2","3.3"]
+        ruby: ["3.1","3.2","3.3", "3.4"]
+        rails: ["7.1", "7.2", "8.0"]
     env:
-      BUNDLE_GEMFILE: .github/Gemfile
+      BUNDLE_GEMFILE: .github/gemfiles/rails_${{ matrix.rails }}.gemfile
       MYSQL_HOST: 127.0.0.1
       RAILS_ENV: test
     steps:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: ["3.1","3.2","3.3", "3.4"]
+        ruby: ["3.2","3.3", "3.4"]
         rails: ["7.1", "7.2", "8.0"]
     env:
       BUNDLE_GEMFILE: .github/gemfiles/rails_${{ matrix.rails }}.gemfile

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Define the database connections in `config/database.yml`, e.g.:
 
 ```
 default: &default
-  adapter: mysql2
+  adapter: trilogy
   pool: 5
   username: root
   host: 127.0.0.1

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ default: &default
   adapter: mysql2
   pool: 5
   username: root
-  host: localhost
+  host: 127.0.0.1
   timeout: 5000
   connnect_timeout: 5000
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@ Currently, its implementation is focusing on horizontal database sharding. Howev
 ## Scope of this gem
 
 ### What is included in Octoball
+
 - Octopus-like shard swithcing by `using` class method, e.g.:
+
   ```ruby
   Octoball.using(:shard1) { User.find_by_name("Alice") }
   User.using(:shard1).first
   ```
+
 - Each model instance knows which shard it came from so shard will be switched automatically:
+
   ```ruby
   user1 = User.using(:shard1).find_by_name("Bob")
   user2 = User.using(:shard2).find_by_name("Charlie")
@@ -25,15 +29,18 @@ Currently, its implementation is focusing on horizontal database sharding. Howev
   user1.save!  #  Save the user1 in the correct shard `:shard1`
   user2.save!  #  Save the user2 in the correct shard `:shard2`
   ```
+
 - Relations such as `has_many` are also resolved from the model instance's shard:
+
   ```ruby
   user = User.using(:shard1).find_by_name("Alice")
   user.blogs.where(title: "blog")  # user's blogs are fetched from `:shard1`
   ```
 
 ### What is NOT included in Octoball
+
 - Connection handling and configuration -- managed by the native `ActiveRecord::Base.connects_to` methods introduced in ActiveRecord 6.1.
-  - You need to migrate from Octopus' `config/shards.yml` to [Rails native multiple DB configuration using `config/database.yml`](https://edgeguides.rubyonrails.org/active_record_multiple_databases.html). Please refer the [Setup](#Setup) section for more details.
+  - You need to migrate from Octopus' `config/shards.yml` to [Rails native multiple DB configuration using `config/database.yml`](https://edgeguides.rubyonrails.org/active_record_multiple_databases.html). Please refer the [Setup](#setup) section for more details.
 - Migration -- done by ActiveRecord 6.1+ natively.
   - Instead of `using` method in Octopus, you can specify the `migrations_paths` parameter in the `config/database.yml` file.
 - Replication handling -- done by ActiveRecord's `role`
@@ -46,6 +53,7 @@ gem "octoball"
 ```
 
 Define the database connections in `config/database.yml`, e.g.:
+
 ```
 default: &default
   adapter: mysql2
@@ -63,7 +71,9 @@ development:
     <<: *default
     database: db_shard1
 ```
+
 And define shards and corresponding connections in abstract ActiveRecord model class, e.g.:
+
 ```ruby
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
@@ -80,21 +90,24 @@ end
 ```
 
 Optionally, to use the `:master` shard as a default connection like Octopus, add the following script to `config/initializers/default_shard.rb`:
+
 ```
 ActiveRecord::Base.default_shard = :master
 ```
 
-
 ## Development of Octoball
+
 Octoball has rspec tests delived from subsets of Octopus' rspec.
 
 To run the rspec tests, follow these steps:
+
 ```
 RAILS_ENV=test bundle exec rake db:prepare
 RAILS_ENV=test bundle exec rake spec
 ```
 
 ## License
+
 Octoball is released under the MIT license.
 
 Original Octopus' copyright: Copyright (c) Thiago Pradi

--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,8 @@ namespace :db do
 
   desc 'Create tables on tests databases'
   task :create_tables do
+    require 'active_record'
+
     ActiveRecord::Base.configurations = {
       "test" => {
         shard1: mysql_spec.merge(database: 'octoball_shard_1'),

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ RuboCop::RakeTask.new
 
 namespace :db do
   mysql_spec = {
-    adapter:  'mysql2',
+    adapter:  'trilogy',
     host:     (ENV['MYSQL_HOST'] || '127.0.0.1'),
     username: (ENV['MYSQL_USER'] || 'root'),
     port:     (ENV['MYSQL_PORT'] || 3306),

--- a/Rakefile
+++ b/Rakefile
@@ -10,8 +10,9 @@ RuboCop::RakeTask.new
 namespace :db do
   mysql_spec = {
     adapter:  'mysql2',
-    host:     (ENV['MYSQL_HOST'] || 'localhost'),
+    host:     (ENV['MYSQL_HOST'] || '127.0.0.1'),
     username: (ENV['MYSQL_USER'] || 'root'),
+    port:     (ENV['MYSQL_PORT'] || 3306),
     encoding: 'utf8mb4',
   }
 

--- a/octoball.gemspec
+++ b/octoball.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord', '>= 7.0'
   s.add_dependency 'activesupport', '>= 7.0'
 
-  s.add_development_dependency 'mysql2'
+  s.add_development_dependency 'trilogy'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '>= 3'
   s.add_development_dependency 'rubocop'

--- a/octoball.gemspec
+++ b/octoball.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/aktsk/octoball'
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 3.1.0'
+  s.required_ruby_version = '>= 3.2.0'
 
   s.add_dependency 'activerecord', '>= 7.0'
   s.add_dependency 'activesupport', '>= 7.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
   mysql_spec = {
-    adapter:  'mysql2',
+    adapter:  'trilogy',
     host:     (ENV['MYSQL_HOST'] || '127.0.0.1'),
     username: (ENV['MYSQL_USER'] || 'root'),
     port:     (ENV['MYSQL_PORT'] || 3306),

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,8 +11,9 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
 RSpec.configure do |config|
   mysql_spec = {
     adapter:  'mysql2',
-    host:     (ENV['MYSQL_HOST'] || 'localhost'),
+    host:     (ENV['MYSQL_HOST'] || '127.0.0.1'),
     username: (ENV['MYSQL_USER'] || 'root'),
+    port:     (ENV['MYSQL_PORT'] || 3306),
     encoding: 'utf8mb4',
   }
   ActiveRecord::Base.configurations = {

--- a/spec/support/database_connection.rb
+++ b/spec/support/database_connection.rb
@@ -3,7 +3,7 @@ require 'logger'
 ActiveRecord::Base.logger = Logger.new(File.open('database.log', 'a'))
 
 mysql_spec = {
-  adapter:  'mysql2',
+  adapter:  'trilogy',
   host:     (ENV['MYSQL_HOST'] || '127.0.0.1'),
   username: (ENV['MYSQL_USER'] || 'root'),
   port:     (ENV['MYSQL_PORT'] || 3306),

--- a/spec/support/database_connection.rb
+++ b/spec/support/database_connection.rb
@@ -4,8 +4,9 @@ ActiveRecord::Base.logger = Logger.new(File.open('database.log', 'a'))
 
 mysql_spec = {
   adapter:  'mysql2',
-  host:     (ENV['MYSQL_HOST'] || 'localhost'),
+  host:     (ENV['MYSQL_HOST'] || '127.0.0.1'),
   username: (ENV['MYSQL_USER'] || 'root'),
+  port:     (ENV['MYSQL_PORT'] || 3306),
   encoding: 'utf8mb4',
 }
 

--- a/spec/support/database_models.rb
+++ b/spec/support/database_models.rb
@@ -20,7 +20,7 @@ end
 # This class sets its own connection
 class CustomConnectionBase < ActiveRecord::Base
   self.abstract_class = true
-  establish_connection(:adapter => 'mysql2', :host => (ENV['MYSQL_HOST'] || 'localhost'), :database => 'octoball_shard_2', :username => "#{ENV['MYSQL_USER'] || 'root'}", :password => '')
+  establish_connection(:adapter => 'mysql2', :host => (ENV['MYSQL_HOST'] || '127.0.0.1'), :database => 'octoball_shard_2', :username => "#{ENV['MYSQL_USER'] || 'root'}", :password => '', :port => (ENV['MYSQL_PORT'] || 3306))
   connects_to shards: {
     custom_shard: { writing: :shard3 }
   }

--- a/spec/support/database_models.rb
+++ b/spec/support/database_models.rb
@@ -20,7 +20,7 @@ end
 # This class sets its own connection
 class CustomConnectionBase < ActiveRecord::Base
   self.abstract_class = true
-  establish_connection(:adapter => 'mysql2', :host => (ENV['MYSQL_HOST'] || '127.0.0.1'), :database => 'octoball_shard_2', :username => "#{ENV['MYSQL_USER'] || 'root'}", :password => '', :port => (ENV['MYSQL_PORT'] || 3306))
+  establish_connection(:adapter => 'trilogy', :host => (ENV['MYSQL_HOST'] || '127.0.0.1'), :database => 'octoball_shard_2', :username => "#{ENV['MYSQL_USER'] || 'root'}", :password => '', :port => (ENV['MYSQL_PORT'] || 3306))
   connects_to shards: {
     custom_shard: { writing: :shard3 }
   }


### PR DESCRIPTION
## Overview
Enhanced the GitHub Actions CI configuration to support Ruby×Rails matrix testing.
This allows automated testing across combinations of Ruby 3.2-3.3 and Rails 7.1/8.0.

Drop ruby 3.1 support (already EOL)

## Changes
1. Modified GitHub Actions configuration file (.github/workflows/rspec.yml)
   - Added matrix configuration for Ruby versions (3.2/3.3/3.4) and Rails versions (7.x/8.0)
   - Set environment variables to reference version-specific Gemfiles

2. Created Rails version-specific Gemfiles
   - .github/gemfiles/rails_7.1.gemfile
   - .github/gemfiles/rails_7.2.gemfile
   - .github/gemfiles/rails_8.0.gemfile

3. Minor fixes
  - Change mysql adapter (mysql2 → trilogy) 3cea423e94a7806c7d6676f3160a2e92a9ed8718
  - fix spec configurations 919af4bd91a7f57bd2af9539de96db4a14579d2e

## Test Matrix
Tests will automatically run with the following combinations:

| Ruby | Rails |
|------|-------|
| 3.2  | 7.1   |
| 3.2  | 7.2   |
| 3.2  | 8.0   |
| 3.3  | 7.1   |
| 3.3  | 7.2   |
| 3.3  | 8.0   |
| 3.4  | 7.1   |
| 3.4  | 7.2   |
| 3.4  | 8.0   |

