### PR TITLE
Fix keyword argument forwarding for Ruby 3

### DIFF
--- a/lib/octoball/persistence.rb
+++ b/lib/octoball/persistence.rb
@@ -7,13 +7,12 @@ class Octoball
     [:update_columns, :increment!, :reload, :_delete_row, :_touch_row, :_update_row, :_create_record,
      :transaction, :with_transaction_returning_status].each do |method|
       class_eval <<-"END", __FILE__, __LINE__ + 1
-        def #{method}(*args, &block)
-          return super if !current_shard || current_shard == ActiveRecord::Base.current_shard
+        def #{method}(*args, **kwargs, &block)
+          return super(*args, **kwargs, &block) if !current_shard || current_shard == ActiveRecord::Base.current_shard
           ActiveRecord::Base.connected_to(shard: current_shard, role: Octoball.current_role) do
-            super
+            super(*args, **kwargs, &block)
           end
         end
-        ruby2_keywords(:#{method}) if respond_to?(:ruby2_keywords, true)
       END
     end
 

--- a/lib/octoball/relation_proxy.rb
+++ b/lib/octoball/relation_proxy.rb
@@ -33,26 +33,25 @@ class Octoball
     end + [:each, :map, :index_by]
     ENUM_WITH_BLOCK_METHODS = [:find, :select, :none?, :any?, :one?, :many?, :sum]
 
-    def method_missing(method, *args, &block)
+    def method_missing(method, *args, **kwargs, &block)
       # raise NoMethodError unless the method is defined in @rel
-      return @rel.public_send(method, *args, &block) unless @rel.respond_to?(method)
+      return @rel.public_send(method, *args, **kwargs, &block) unless @rel.respond_to?(method)
 
       preamble = <<-EOS
-        def #{method}(*margs, &mblock)
-          return @rel.#{method}(*margs, &mblock) unless @current_shard
+        def #{method}(*margs, **mkwargs, &mblock)
+          return @rel.#{method}(*margs, **mkwargs, &mblock) unless @current_shard
       EOS
       postamble = <<-EOS
           return ret unless ret.is_a?(::ActiveRecord::Relation) || ret.is_a?(::ActiveRecord::QueryMethods::WhereChain) || ret.is_a?(::Enumerator)
           ::Octoball::RelationProxy.new(ret, @current_shard)
         end
-        ruby2_keywords(:#{method}) if respond_to?(:ruby2_keywords, true)
       EOS
       connected_to = '::ActiveRecord::Base.connected_to(role: ::Octoball.current_role, shard: @current_shard)'
 
       if ENUM_METHODS.include?(method)
         ::Octoball::RelationProxy.class_eval <<-EOS, __FILE__, __LINE__ - 1
           #{preamble}
-          ret = #{connected_to} { @rel.to_a }.#{method}(*margs, &mblock)
+          ret = #{connected_to} { @rel.to_a }.#{method}(*margs, **mkwargs, &mblock)
           #{postamble}
         EOS
       elsif ENUM_WITH_BLOCK_METHODS.include?(method)
@@ -60,9 +59,9 @@ class Octoball
           #{preamble}
           ret = nil
           if mblock
-            ret = #{connected_to} { @rel.to_a }.#{method}(*margs, &mblock)
+            ret = #{connected_to} { @rel.to_a }.#{method}(*margs, **mkwargs, &mblock)
           else
-            #{connected_to} { ret = @rel.#{method}(*margs, &mblock); nil } # return nil to avoid loading relation
+            #{connected_to} { ret = @rel.#{method}(*margs, **mkwargs, &mblock); nil } # return nil to avoid loading relation
           end
           #{postamble}
         EOS
@@ -70,14 +69,13 @@ class Octoball
         ::Octoball::RelationProxy.class_eval <<-EOS, __FILE__, __LINE__ - 1
           #{preamble}
           ret = nil
-          #{connected_to} { ret = @rel.#{method}(*margs, &mblock); nil } # return nil to avoid loading relation
+          #{connected_to} { ret = @rel.#{method}(*margs, **mkwargs, &mblock); nil } # return nil to avoid loading relation
           #{postamble}
         EOS
       end
 
-      public_send(method, *args, &block)
+      public_send(method, *args, **kwargs, &block)
     end
-    ruby2_keywords(:method_missing) if respond_to?(:ruby2_keywords, true)
 
     def inspect
       return @rel.inspect unless @current_shard


### PR DESCRIPTION
## Changes

This PR updates argument forwarding in octoball to properly support Ruby 3 keyword argument semantics.

* Explicitly accept and forward **kwargs in association, persistence, and relation proxy methods
* Replace implicit keyword forwarding via ruby2_keywords
* Ensure keyword arguments are correctly passed through shard switching wrappers

Since octoball targets Ruby 3.2+, this aligns the implementation with Ruby 3 behavior and prevents keyword-related ArgumentError when calling ActiveRecord APIs.